### PR TITLE
CHORE #14: Creates domain specific translation units for top-level entrypoint functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ option(BUILD_SHARED_LIBS "Build the shared library" ON)
 # Set the project name and version.
 project(StochasticModels
     DESCRIPTION "Core stochastic differential equation implementation of fast mathematical tools for stochastic calculus."
-    VERSION 0.1.3
+    VERSION 0.1.5
     LANGUAGES CXX)
 
 # specify the C++ standard.
@@ -49,8 +49,8 @@ add_subdirectory(tests)
 
 # create config file
 configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/Config.cmake.in
-"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-INSTALL_DESTINATION cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )
 
 # CMake sets this variable to a ``TRUE`` value when the
@@ -99,5 +99,5 @@ install(TARGETS ${PROJECT_NAME}
 # generate and install export file
 install(EXPORT "${PROJECT_NAME}Targets"
     FILE "${PROJECT_NAME}Targets.cmake"
-    DESTINATION cmake
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
 )

--- a/include/stochastic_models/entrypoints/kca.h
+++ b/include/stochastic_models/entrypoints/kca.h
@@ -1,0 +1,40 @@
+#ifndef KCA_H
+#define KCA_H
+#include <string>
+#include <vector>
+
+/**
+ * @brief Returns a JSON string containing an intialized kinetic components
+ * state given the parameters provided.
+ *
+ * @param data_series The data series to initialize the filter with.
+ * @param h A value determining the first and second derivative values of
+ * the KCA system.
+ * @param q A value determining the transition covariance of the KCA system.
+ * @param system_dimensions A type containing the dimensions of the system
+ * components.
+ * @return const std::string The JSON string containing the initialized KCA
+ * state.
+ */
+const std::string getInitializedKcaState(const std::vector<double> data_series,
+                                         const double h, const double q,
+                                         const std::string system_dimensions);
+/**
+ * @brief Takes a current kinetic components state and returns a JSON string
+ * containing a single step update of the state and the value of the observation
+ * provided.
+ *
+ * @param state A JSON string containing current state of the KCA system.
+ * @param system_dimensions A type containing the dimensions of the system
+ * components.
+ * @param observation The next observation to update the system with.
+ * @param innovation_sigma The sigma value of the innovation of the observed
+ * data.
+ * @return const std::string The JSON string containing the updated KCA state.
+ */
+const std::string getUpdatedKcaState(const std::string state,
+                                     const std::string system_dimensions,
+                                     const double observation,
+                                     const double innovation_sigma);
+
+#endif  // KCA_H

--- a/include/stochastic_models/entrypoints/kca_filter.h
+++ b/include/stochastic_models/entrypoints/kca_filter.h
@@ -1,5 +1,5 @@
-#ifndef KCA_H
-#define KCA_H
+#ifndef KCA_FILTER_H
+#define KCA_FILTER_H
 #include <string>
 #include <vector>
 
@@ -37,4 +37,4 @@ const std::string getUpdatedKcaState(const std::string state,
                                      const double observation,
                                      const double innovation_sigma);
 
-#endif  // KCA_H
+#endif  // KCA_FILTER_H

--- a/include/stochastic_models/entrypoints/optimal_trading_levels.h
+++ b/include/stochastic_models/entrypoints/optimal_trading_levels.h
@@ -1,5 +1,5 @@
-#ifndef STOCHASTIC_models_H
-#define STOCHASTIC_models_H
+#ifndef OPTIMAL_TRADING_LEVELS_H
+#define OPTIMAL_TRADING_LEVELS_H
 
 /**
  * @brief Calculate the optimal trading level exit value when a stop loss is
@@ -125,4 +125,4 @@ const double optimalEntryLevel(const double b_star, const double mu,
                                const double alpha, const double sigma,
                                const double r, const double c);
 
-#endif  // STOCHASTIC_models_H
+#endif  // OPTIMAL_TRADING_LEVELS_H

--- a/include/stochastic_models/entrypoints/optimal_trading_levels.h
+++ b/include/stochastic_models/entrypoints/optimal_trading_levels.h
@@ -1,11 +1,6 @@
 #ifndef STOCHASTIC_models_H
 #define STOCHASTIC_models_H
 
-#include <string>
-#include <unordered_map>
-#include <vector>
-
-#include "stochastic_models/kalman_filter/filter.h"
 /**
  * @brief Calculate the optimal trading level exit value when a stop loss is
  * provided.
@@ -129,67 +124,5 @@ const double optimalEntryLevel(const double b_star, const double mu,
 const double optimalEntryLevel(const double b_star, const double mu,
                                const double alpha, const double sigma,
                                const double r, const double c);
-/**
- * @brief Calculates the probability of hitting the level first before second
- * given the parameters provided.
- *
- * @param x The starting point of the hitting time density calculation.
- * @param mu The series mean.
- * @param alpha The series mean reversion speed.
- * @param sigma The series volatility.
- * @param first The first level that is hit.
- * @param second The level first is assumed to be hit before.
- * @return const double The probability of hitting the level first before
- * second.
- */
-const double hittingTimeDensityOrnsteinUhlenbeck(double x, const double mu,
-                                                 const double alpha,
-                                                 const double sigma,
-                                                 double first, double second);
-/**
- * @brief Calculate the maximum likelihood estimates of the
- * Ornstein-Uhlenbeck model parameters using the series in vec.
- *
- * @param vec The series to calculate the maximum likelihood estimates of
- * the Ornstein-Uhlenbeck model with.
- * @return const std::unordered_map<std::string, const double> The maximum
- * likelihood estimates of the Ornstein-Uhlenbeck model parameters.
- */
-const std::unordered_map<std::string, const double>
-ornsteinUhlenbeckMaximumLikelihood(const std::vector<double> vec);
-
-/**
- * @brief Returns a JSON string containing an intialized kinetic components
- * state given the parameters provided.
- *
- * @param data_series The data series to initialize the filter with.
- * @param h A value determining the first and second derivative values of
- * the KCA system.
- * @param q A value determining the transition covariance of the KCA system.
- * @param system_dimensions A type containing the dimensions of the system
- * components.
- * @return const std::string The JSON string containing the initialized KCA
- * state.
- */
-const std::string getInitializedKcaState(const std::vector<double> data_series,
-                                         const double h, const double q,
-                                         const std::string system_dimensions);
-/**
- * @brief Takes a current kinetic components state and returns a JSON string
- * containing a single step update of the state and the value of the observation
- * provided.
- *
- * @param state A JSON string containing current state of the KCA system.
- * @param system_dimensions A type containing the dimensions of the system
- * components.
- * @param observation The next observation to update the system with.
- * @param innovation_sigma The sigma value of the innovation of the observed
- * data.
- * @return const std::string The JSON string containing the updated KCA state.
- */
-const std::string getUpdatedKcaState(const std::string state,
-                                     const std::string system_dimensions,
-                                     const double observation,
-                                     const double innovation_sigma);
 
 #endif  // STOCHASTIC_models_H

--- a/include/stochastic_models/entrypoints/ou_model.h
+++ b/include/stochastic_models/entrypoints/ou_model.h
@@ -1,0 +1,36 @@
+#ifndef OU_MODEL_H
+#define OU_MODEL_H
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+/**
+ * @brief Calculates the probability of hitting the level first before second
+ * given the parameters provided.
+ *
+ * @param x The starting point of the hitting time density calculation.
+ * @param mu The series mean.
+ * @param alpha The series mean reversion speed.
+ * @param sigma The series volatility.
+ * @param first The first level that is hit.
+ * @param second The level first is assumed to be hit before.
+ * @return const double The probability of hitting the level first before
+ * second.
+ */
+const double hittingTimeDensityOrnsteinUhlenbeck(double x, const double mu,
+                                                 const double alpha,
+                                                 const double sigma,
+                                                 double first, double second);
+/**
+ * @brief Calculate the maximum likelihood estimates of the
+ * Ornstein-Uhlenbeck model parameters using the series in vec.
+ *
+ * @param vec The series to calculate the maximum likelihood estimates of
+ * the Ornstein-Uhlenbeck model with.
+ * @return const std::unordered_map<std::string, const double> The maximum
+ * likelihood estimates of the Ornstein-Uhlenbeck model parameters.
+ */
+const std::unordered_map<std::string, const double>
+ornsteinUhlenbeckMaximumLikelihood(const std::vector<double> vec);
+
+#endif  // OU_MODEL_H

--- a/include/stochastic_models/entrypoints/ou_model.h
+++ b/include/stochastic_models/entrypoints/ou_model.h
@@ -5,6 +5,22 @@
 #include <vector>
 
 /**
+ * @brief Simulates an Ornstein-Uhlenbeck process of size provided in the
+ * method arguments using the parameters mu, alpha, and sigma of the class
+ * instance.
+ * @param mu The series mean.
+ * @param alpha The series mean reversion speed.
+ * @param sigma The series volatility.
+ * @param start The value to start the simulation at.
+ * @param size The number of values to simulate.
+ * @param t The time period to simulate over.
+ * @return std::vector<double> A simulated Ornstein-Uhlenbeck process series.
+ */
+const std::vector<double> simulateOrnsteinUhlenbeck(
+    const double& mu, const double& alpha, const double& sigma,
+    const double start, const unsigned int& size, const unsigned int& t);
+
+/**
  * @brief Calculates the probability of hitting the level first before second
  * given the parameters provided.
  *

--- a/include/stochastic_models/kalman_filter/kca.h
+++ b/include/stochastic_models/kalman_filter/kca.h
@@ -1,5 +1,5 @@
-#ifndef FILTER_H
-#define FILTER_H
+#ifndef KCA_H
+#define KCA_H
 
 #include "stochastic_models/kalman_filter/states.h"
 
@@ -56,4 +56,4 @@ class KineticComponents {
     const std::vector<double> getStateVector() const;
     const std::vector<double> getStandardDevVector() const;
 };
-#endif  // FILTER_H
+#endif  // KCA_H

--- a/include/stochastic_models/kalman_filter/kca.h
+++ b/include/stochastic_models/kalman_filter/kca.h
@@ -2,6 +2,7 @@
 #define FILTER_H
 
 #include "stochastic_models/kalman_filter/states.h"
+
 /**
  * @brief Class to expose an interface to use the Kinetic components analysis
  * implementation of the kalman filter to users of this library.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,10 +37,10 @@ PRIVATE
 "${PROJECT_SOURCE_DIR}/include"
 PUBLIC
 # where top-level project will look for the library's public headers
-$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/stochastic_models/interface>
+$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/stochastic_models/entrypoints>
 $<BUILD_INTERFACE:${boost_SOURCE_DIR}>
 # where external projects will look for the library's public headers
-$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/interface>
+$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/entrypointse>
 )
 
 target_link_libraries(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ ornstein_uhlenbeck.cpp
 core.cpp
 gaussian.cpp
 gsl_errors.cpp
-filter.cpp
+kca.cpp
 states.cpp
 states_exceptions.cpp
 linalg.cpp
@@ -26,7 +26,10 @@ trading_levels.cpp
 trading_levels_exponential.cpp
 trading_levels_params.cpp
 type_conversion.cpp
-interface.cpp)
+entrypoint_optimal_trading_levels.cpp
+entrypoint_kca_filter.cpp
+entrypoint_ou_model.cpp
+)
 
 target_include_directories(stochastic_models
 PRIVATE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,7 @@ PUBLIC
 $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include/stochastic_models/entrypoints>
 $<BUILD_INTERFACE:${boost_SOURCE_DIR}>
 # where external projects will look for the library's public headers
-$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/entrypointse>
+$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/entrypoints>
 )
 
 target_link_libraries(

--- a/src/entrypoint_kca_filter.cpp
+++ b/src/entrypoint_kca_filter.cpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "stochastic_models/entrypoints/kca.h"
+#include "stochastic_models/entrypoints/kca_filter.h"
 #include "stochastic_models/kalman_filter/adapters.h"
 #include "stochastic_models/kalman_filter/kca.h"
 

--- a/src/entrypoint_kca_filter.cpp
+++ b/src/entrypoint_kca_filter.cpp
@@ -1,0 +1,68 @@
+/**
+ * @file entrypoint_kca_filter.cpp
+ * @brief Entry point module for Kinetic Components Analysis initialization and
+ * update steps.
+ *
+ */
+#include <string>
+#include <vector>
+
+#include "stochastic_models/entrypoints/kca.h"
+#include "stochastic_models/kalman_filter/adapters.h"
+#include "stochastic_models/kalman_filter/kca.h"
+
+const std::string getInitializedKcaState(const std::vector<double> data_series,
+                                         const double h, const double q,
+                                         const std::string system_dimensions) {
+    // Deserialize the initial dimensions of the filter system that were
+    // provided in the initial state.
+    const FilterSystemDimensionsJsonAdapter dimensions_adapter;
+    const FilterSystemDimensions dimensions =
+        dimensions_adapter.deserialize(system_dimensions);
+
+    // Create kinetic components object.
+    KineticComponents kinetic_components = KineticComponents{dimensions};
+
+    // Initialize the filter with the provided data series and parameters.
+    kinetic_components.initialiseFilter(data_series, h, q);
+
+    // Return the internal state of the filter.
+    const KcaStates internal_state = kinetic_components.getFilterState();
+
+    const KcaStatesJsonAdapter state_adapter;
+    return state_adapter.serialize(internal_state);
+}
+const std::string getUpdatedKcaState(const std::string state,
+                                     const std::string system_dimensions,
+                                     const double observation,
+                                     const double innovation_sigma) {
+    // Deserialize the initial dimensions of the filter system that were
+    // provided in the initial state.
+    const FilterSystemDimensionsJsonAdapter dimensions_adapter;
+    const FilterSystemDimensions dimensions =
+        dimensions_adapter.deserialize(system_dimensions);
+
+    // Create JSON adapter to handle serialisation and deserialisation of
+    // the internal state provided.
+    KcaStatesJsonAdapter adapter;
+
+    // Set the internal state of the filter with the state matrices /
+    // vectors provided.
+    KcaStates internal_state = adapter.deserialize(state, dimensions);
+
+    // Create kinetic components object and set the filter state with the
+    // provided internal state.
+    KineticComponents kinetic_components = KineticComponents{dimensions};
+    kinetic_components.setFilterState(internal_state);
+
+    // Update priors and posteriors with the provided observation and
+    // innovation sigma.
+    kinetic_components.updatePriors();
+    kinetic_components.updatePosteriors(observation, innovation_sigma);
+
+    // Return the internal state of the filter.
+    const KcaStates updated_state = kinetic_components.getFilterState();
+
+    // serialize the internal state to a JSON string before returning.
+    return adapter.serialize(updated_state);
+}

--- a/src/entrypoint_optimal_trading_levels.cpp
+++ b/src/entrypoint_optimal_trading_levels.cpp
@@ -1,13 +1,12 @@
 /**
- * @file interface.cpp
- * @brief Interface module to the stochastic engine library.
+ * @file entrypoint_optimal_trading_levels.cpp
+ * @brief Entry point module for optimal entry and exit trading levels
+ * calculations.
  *
  */
-#include "stochastic_models/hitting_times/hitting_time_density.h"
-#include "stochastic_models/interface/stochastic_models.h"
-#include "stochastic_models/kalman_filter/adapters.h"
-#include "stochastic_models/likelihood/ornstein_uhlenbeck_likelihood.h"
-#include "stochastic_models/sde/ornstein_uhlenbeck.h"
+#include <iostream>
+
+#include "stochastic_models/entrypoints/optimal_trading_levels.h"
 #include "stochastic_models/trading/exponential_mean_reversion.h"
 #include "stochastic_models/trading/optimal_mean_reversion.h"
 #include "stochastic_models/trading/trading_levels.h"
@@ -180,94 +179,4 @@ const double optimalEntryLevel(const double b_star, const double mu,
         throw;
     }
     return value;
-}
-const double hittingTimeDensityOrnsteinUhlenbeck(double x, const double mu,
-                                                 const double alpha,
-                                                 const double sigma,
-                                                 double first, double second) {
-    // Create core model as pointer to void because that type is required by
-    // GSL.
-    void *model = new HittingTimeOrnsteinUhlenbeck(mu, alpha, sigma);
-
-    // The ModelFunc is provided to determine which function to provide to
-    // GSL for integration.
-    ModelFunc fn = &integrateHittingTimeDensity;
-
-    // Calculate the hitting time density at point x given the arguments
-    // first and second.
-    const double value = hittingTimeDensity(x, fn, model, first, second);
-
-    // Then need to cast model back to OrnsteinUhlenbeckModel pointer to
-    // clean up.
-    HittingTimeOrnsteinUhlenbeck *ptr =
-        static_cast<HittingTimeOrnsteinUhlenbeck *>(model);
-    delete ptr;
-    ptr = nullptr;
-    model = nullptr;
-    return value;
-}
-const std::unordered_map<std::string, const double>
-ornsteinUhlenbeckMaximumLikelihood(const std::vector<double> vec) {
-    // Generate likelihood calculator and generate estimate of mu, alpha,
-    // and sigma.
-    OrnsteinUhlenbeckLikelihood *likelihood = new OrnsteinUhlenbeckLikelihood();
-    const std::unordered_map<std::string, const double> params{
-        likelihood->calculate(vec)};
-    delete likelihood;
-    return params;
-}
-const std::string getInitializedKcaState(const std::vector<double> data_series,
-                                         const double h, const double q,
-                                         const std::string system_dimensions) {
-    // Deserialize the initial dimensions of the filter system that were
-    // provided in the initial state.
-    const FilterSystemDimensionsJsonAdapter dimensions_adapter;
-    const FilterSystemDimensions dimensions =
-        dimensions_adapter.deserialize(system_dimensions);
-
-    // Create kinetic components object.
-    KineticComponents kinetic_components = KineticComponents{dimensions};
-
-    // Initialize the filter with the provided data series and parameters.
-    kinetic_components.initialiseFilter(data_series, h, q);
-
-    // Return the internal state of the filter.
-    const KcaStates internal_state = kinetic_components.getFilterState();
-
-    const KcaStatesJsonAdapter state_adapter;
-    return state_adapter.serialize(internal_state);
-}
-const std::string getUpdatedKcaState(const std::string state,
-                                     const std::string system_dimensions,
-                                     const double observation,
-                                     const double innovation_sigma) {
-    // Deserialize the initial dimensions of the filter system that were
-    // provided in the initial state.
-    const FilterSystemDimensionsJsonAdapter dimensions_adapter;
-    const FilterSystemDimensions dimensions =
-        dimensions_adapter.deserialize(system_dimensions);
-
-    // Create JSON adapter to handle serialisation and deserialisation of
-    // the internal state provided.
-    KcaStatesJsonAdapter adapter;
-
-    // Set the internal state of the filter with the state matrices /
-    // vectors provided.
-    KcaStates internal_state = adapter.deserialize(state, dimensions);
-
-    // Create kinetic components object and set the filter state with the
-    // provided internal state.
-    KineticComponents kinetic_components = KineticComponents{dimensions};
-    kinetic_components.setFilterState(internal_state);
-
-    // Update priors and posteriors with the provided observation and
-    // innovation sigma.
-    kinetic_components.updatePriors();
-    kinetic_components.updatePosteriors(observation, innovation_sigma);
-
-    // Return the internal state of the filter.
-    const KcaStates updated_state = kinetic_components.getFilterState();
-
-    // serialize the internal state to a JSON string before returning.
-    return adapter.serialize(updated_state);
 }

--- a/src/entrypoint_ou_model.cpp
+++ b/src/entrypoint_ou_model.cpp
@@ -1,0 +1,48 @@
+/**
+ * @file entrypoint_ou_model.cpp
+ * @brief Entry point module for Ornstein Uhlenbeck process calculation
+ * functions.
+ *
+ */
+
+#include "stochastic_models/entrypoints/ou_model.h"
+#include "stochastic_models/hitting_times/hitting_time_density.h"
+#include "stochastic_models/hitting_times/hitting_time_ornstein_uhlenbeck.h"
+#include "stochastic_models/likelihood/ornstein_uhlenbeck_likelihood.h"
+#include "stochastic_models/sde/ornstein_uhlenbeck.h"
+
+const double hittingTimeDensityOrnsteinUhlenbeck(double x, const double mu,
+                                                 const double alpha,
+                                                 const double sigma,
+                                                 double first, double second) {
+    // Create core model as pointer to void because that type is required by
+    // GSL.
+    void *model = new HittingTimeOrnsteinUhlenbeck(mu, alpha, sigma);
+
+    // The ModelFunc is provided to determine which function to provide to
+    // GSL for integration.
+    ModelFunc fn = &integrateHittingTimeDensity;
+
+    // Calculate the hitting time density at point x given the arguments
+    // first and second.
+    const double value = hittingTimeDensity(x, fn, model, first, second);
+
+    // Then need to cast model back to OrnsteinUhlenbeckModel pointer to
+    // clean up.
+    HittingTimeOrnsteinUhlenbeck *ptr =
+        static_cast<HittingTimeOrnsteinUhlenbeck *>(model);
+    delete ptr;
+    ptr = nullptr;
+    model = nullptr;
+    return value;
+}
+const std::unordered_map<std::string, const double>
+ornsteinUhlenbeckMaximumLikelihood(const std::vector<double> vec) {
+    // Generate likelihood calculator and generate estimate of mu, alpha,
+    // and sigma.
+    OrnsteinUhlenbeckLikelihood *likelihood = new OrnsteinUhlenbeckLikelihood();
+    const std::unordered_map<std::string, const double> params{
+        likelihood->calculate(vec)};
+    delete likelihood;
+    return params;
+}

--- a/src/entrypoint_ou_model.cpp
+++ b/src/entrypoint_ou_model.cpp
@@ -11,13 +11,23 @@
 #include "stochastic_models/likelihood/ornstein_uhlenbeck_likelihood.h"
 #include "stochastic_models/sde/ornstein_uhlenbeck.h"
 
+const std::vector<double> simulateOrnsteinUhlenbeck(
+    const double& mu, const double& alpha, const double& sigma,
+    const double start, const unsigned int& size, const unsigned int& t) {
+    // Create the Ornstein-Uhlenbeck process model
+    OrnsteinUhlenbeckModel model(mu, alpha, sigma);
+
+    // Simulate the process
+    return model.Simulate(start, size, t);
+}
+
 const double hittingTimeDensityOrnsteinUhlenbeck(double x, const double mu,
                                                  const double alpha,
                                                  const double sigma,
                                                  double first, double second) {
     // Create core model as pointer to void because that type is required by
     // GSL.
-    void *model = new HittingTimeOrnsteinUhlenbeck(mu, alpha, sigma);
+    void* model = new HittingTimeOrnsteinUhlenbeck(mu, alpha, sigma);
 
     // The ModelFunc is provided to determine which function to provide to
     // GSL for integration.
@@ -29,8 +39,8 @@ const double hittingTimeDensityOrnsteinUhlenbeck(double x, const double mu,
 
     // Then need to cast model back to OrnsteinUhlenbeckModel pointer to
     // clean up.
-    HittingTimeOrnsteinUhlenbeck *ptr =
-        static_cast<HittingTimeOrnsteinUhlenbeck *>(model);
+    HittingTimeOrnsteinUhlenbeck* ptr =
+        static_cast<HittingTimeOrnsteinUhlenbeck*>(model);
     delete ptr;
     ptr = nullptr;
     model = nullptr;
@@ -40,7 +50,7 @@ const std::unordered_map<std::string, const double>
 ornsteinUhlenbeckMaximumLikelihood(const std::vector<double> vec) {
     // Generate likelihood calculator and generate estimate of mu, alpha,
     // and sigma.
-    OrnsteinUhlenbeckLikelihood *likelihood = new OrnsteinUhlenbeckLikelihood();
+    OrnsteinUhlenbeckLikelihood* likelihood = new OrnsteinUhlenbeckLikelihood();
     const std::unordered_map<std::string, const double> params{
         likelihood->calculate(vec)};
     delete likelihood;

--- a/src/kca.cpp
+++ b/src/kca.cpp
@@ -1,4 +1,4 @@
-#include "stochastic_models/kalman_filter/filter.h"
+#include "stochastic_models/kalman_filter/kca.h"
 
 #include <utility>
 

--- a/src/ornstein_uhlenbeck.cpp
+++ b/src/ornstein_uhlenbeck.cpp
@@ -46,11 +46,12 @@ const double OrnsteinUhlenbeckModel::getUnconditionalVariance() const {
 }
 std::vector<double> OrnsteinUhlenbeckModel::Simulate(
     const double start, const unsigned int& size, const unsigned int& t) const {
-    const std::vector<double> distribution_draws = (*dist).sample(size);
+    const std::vector<double> distribution_draws = (*dist).sample(size - 1);
     std::vector<double> vec = {start};
 
-    for (unsigned int n{}; n < size; n++) {
-        const double sample = coreEquation(vec[n], distribution_draws[n], t);
+    for (const unsigned int& val : distribution_draws) {
+        const double& last = vec.back();
+        const double sample = coreEquation(last, val, t);
         vec.push_back(sample);
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,9 @@ add_executable(
     ornstein_uhlenbeck_test.cpp
     hitting_time_test.cpp
     trading_levels_test.cpp
-    interface_test.cpp
+    kca_filter_test.cpp
+    ou_model_test.cpp
+    optimal_trading_levels_test.cpp
     utils_test.cpp)
 
 

--- a/tests/filter_update_test.cpp
+++ b/tests/filter_update_test.cpp
@@ -1,7 +1,7 @@
 
 #include <gtest/gtest.h>
 
-#include "stochastic_models/kalman_filter/filter.h"
+#include "stochastic_models/kalman_filter/kca.h"
 /**
  * @brief Test that the KineticComponents initialiseFilter sets a
  * KinetiComponents instance to the correct initial state. Members are private,

--- a/tests/kca_filter_test.cpp
+++ b/tests/kca_filter_test.cpp
@@ -1,8 +1,8 @@
+#include "stochastic_models/entrypoints/kca_filter.h"
+
 #include <gtest/gtest.h>
 
 #include <cstdlib>
-
-#include "stochastic_models/entrypoints/kca.h"
 
 /**
  * @test Tests that the getInitializedKcaState function correctly initialises

--- a/tests/kca_filter_test.cpp
+++ b/tests/kca_filter_test.cpp
@@ -1,0 +1,80 @@
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+#include "stochastic_models/entrypoints/kca.h"
+
+/**
+ * @test Tests that the getInitializedKcaState function correctly initialises
+ * a KcaStates object and returns its internal state as a JSON string with the
+ * correct values.
+ *
+ */
+TEST(KcaTest, getInitializedKcaStateTest) {
+    // Mock data to initialise the system.
+    const std::vector<double> data_series{
+        10.51255, 10.51985, 10.52405, 10.4656,  10.47,    10.5403,  10.4425,
+        10.3087,  10.1994,  10.1839,  10.24645, 10.1795,  10.21715, 10.14995,
+        10.194,   10.22505, 10.27325, 10.25095, 10.30575, 10.27645};
+    const double h{1.0};
+    const double q{0.001};
+    const std::string system_dimension =
+        "{\"observation_covariance_columns\":1,\"observation_covariance_rows\":"
+        "1,\"observation_matrix_columns\":3,\"observation_matrix_rows\":1,"
+        "\"observation_offset\":0.0,\"state_covariance_columns\":3,\"state_"
+        "covariance_rows\":3,\"state_mean_dimension\":3}";
+
+    // Get the initialised internal state as a JSON string from the KCA system.
+    const std::string internal_state =
+        getInitializedKcaState(data_series, h, q, system_dimension);
+    std::cout << internal_state << std::endl;
+    EXPECT_EQ(internal_state,
+              "{\"current_state_covariance\":[[0.0,0.0,0.0],[0.0,0.0,0.0],[0.0,"
+              "0.0,0.0]],\"current_state_mean\":[10.288741828687053,0.0,0.0],"
+              "\"observation_matrix\":[[1.0,0.0,0.0]],\"observation_offset\":0."
+              "0,\"transition_covariance\":[[0.12695229227341848,0.0,0.0],[0.0,"
+              "0.001,0.0],[0.0,0.0,0.001]],\"transition_matrix\":[[1."
+              "0011961162353782,1.0,0.5],[0.0,1.0,1.0],[0.0,0.0,1.0]]}")
+        << "The JSON string produced by the getInitializedKcaState "
+           "function is incorrect.";
+}
+/**
+ * @test Tests that the getUpdatedKcaState function correctly performs single
+ * stage update to the KCA system provided and returns a JSON object
+ * representing the correct internal state.
+ *
+ */
+TEST(KcaTest, getUpdatedKcaStateTest) {
+    // Mock data to set the current state of the system.
+    const std::string state =
+        "{\"current_state_covariance\":[[0.0,0.0,0.0],[0.0,0.0,0.0],[0.0,"
+        "0.0,0.0]],\"current_state_mean\":[10.288741828687053,0.0,0.0],"
+        "\"observation_matrix\":[[1.0,0.0,0.0]],\"observation_offset\":0."
+        "0,\"transition_covariance\":[[0.12695229227341848,0.0,0.0],[0.0,"
+        "0.001,0.0],[0.0,0.0,0.001]],\"transition_matrix\":[[1."
+        "0011961162353782,1.0,0.5],[0.0,1.0,1.0],[0.0,0.0,1.0]]}";
+    const std::string system_dimension =
+        "{\"observation_covariance_columns\":1,\"observation_covariance_rows\":"
+        "1,\"observation_matrix_columns\":3,\"observation_matrix_rows\":1,"
+        "\"observation_offset\":0.0,\"state_covariance_columns\":3,\"state_"
+        "covariance_rows\":3,\"state_mean_dimension\":3}";
+    const double observation{10.3};
+    const double innovation_sigma{0.1};
+
+    // Get the updated internal kinetic components state.
+    const std::string updated_state = getUpdatedKcaState(
+        state, system_dimension, observation, innovation_sigma);
+
+    std::cout << updated_state << std::endl;
+    EXPECT_EQ(
+        updated_state,
+        "{\"current_state_covariance\":[[0.009269818720519449,0.0,0.0],[0.0,0."
+        "001,0.0],[0.0,0.0,0.001]],\"current_state_mean\":[10.3000765492722,0."
+        "0,0.0],\"observation_matrix\":[[1.0,0.0,0.0]],\"observation_offset\":"
+        "0.0,\"transition_covariance\":[[0.12695229227341848,0.0,0.0],[0.0,0."
+        "001,0.0],[0.0,0.0,0.001]],\"transition_matrix\":[[1.0011961162353782,"
+        "1.0,0.5],[0.0,1.0,1.0],[0.0,0.0,1.0]]}")
+        << "The JSON string produced "
+           "by the getUpdatedKcaState "
+           "function is incorrect.";
+}

--- a/tests/optimal_trading_levels_test.cpp
+++ b/tests/optimal_trading_levels_test.cpp
@@ -1,15 +1,17 @@
+#include "stochastic_models/entrypoints/optimal_trading_levels.h"
+
 #include <gtest/gtest.h>
 
 #include <cstdlib>
 
-#include "stochastic_models/interface/stochastic_models.h"
 #include "stochastic_models/numeric_utils/helpers.h"
+
 /**
  * @test Tests the output of the optimalEntryLevelLower with a stop loss
  * provided function and asserts that it is near the expected value.
  *
  */
-TEST(InterfaceTest, optimalEntryLowerStopLossOutputTest) {
+TEST(OptimalTradingLevelsTest, optimalEntryLowerStopLossOutputTest) {
     // Declare and initialize model and test parameters.
     const double alpha = 8;
     const double mu = 0.3;
@@ -34,19 +36,18 @@ TEST(InterfaceTest, optimalEntryLowerStopLossOutputTest) {
  * @test Tests that the optimalEntryLevel function errors due to no solution
  * being found with the provided parameters.
  */
-TEST(InterfaceTest, optimalEntryLevelNoSolutionTest) {
+TEST(OptimalTradingLevelsTest, optimalEntryLevelNoSolutionTest) {
     // Declare and initialize model and test parameters.
     const double alpha = 0.000116;
     const double mu = 1.818978;
     const double sigma = 0.006623;
-    const double d_star = 0.436755;
     const double b_star = 0.750895;
     const double c = 0.02;
     const double r = 0.05;
     const float tolerance = 1e-5;
 
     // Assert that the method is not implemented.
-    ASSERT_THROW(optimalEntryLevel(d_star, b_star, mu, alpha, sigma, r, c),
+    ASSERT_THROW(optimalEntryLevel(b_star, mu, alpha, sigma, r, c),
                  std::runtime_error)
         << "optimalEntryLevel did not throw "
            "with invalid parameters.";
@@ -56,7 +57,7 @@ TEST(InterfaceTest, optimalEntryLevelNoSolutionTest) {
  * function and asserts that it is near the expected value.
  *
  */
-TEST(InterfaceTest, optimalEntryLevelStopLossOutputTest) {
+TEST(OptimalTradingLevelsTest, optimalEntryLevelStopLossOutputTest) {
     // Declare and initialize model and test parameters.
     const double alpha = 8;
     const double mu = 0.3;
@@ -81,7 +82,7 @@ TEST(InterfaceTest, optimalEntryLevelStopLossOutputTest) {
  * function and asserts that it is near the expected value.
  *
  */
-TEST(InterfaceTest, optimalExitLevelStopLossOutputTest) {
+TEST(OptimalTradingLevelsTest, optimalExitLevelStopLossOutputTest) {
     // Declare and initialize model and test parameters.
     const double alpha = 8;
     const double mu = 0.3;
@@ -104,7 +105,7 @@ TEST(InterfaceTest, optimalExitLevelStopLossOutputTest) {
  * that it is near the expected value.
  *
  */
-TEST(InterfaceTest, optimalExitLevelOutputTest) {
+TEST(OptimalTradingLevelsTest, optimalExitLevelOutputTest) {
     // Declare and initialize model and test parameters.
     const double alpha = 8;
     const double mu = 0.3;
@@ -126,7 +127,7 @@ TEST(InterfaceTest, optimalExitLevelOutputTest) {
  * asserts that it is near the expected value.
  *
  */
-TEST(InterfaceTest, optimalExitLevelExponentialOutputTest) {
+TEST(OptimalTradingLevelsTest, optimalExitLevelExponentialOutputTest) {
     // Declare and initialize model and test parameters.
     const double alpha = 5;
     const double mu = 1.3499;
@@ -148,7 +149,7 @@ TEST(InterfaceTest, optimalExitLevelExponentialOutputTest) {
  * asserts that it is near the expected value.
  *
  */
-TEST(InterfaceTest, optimalEntryLevelExponentialOutputTest) {
+TEST(OptimalTradingLevelsTest, optimalEntryLevelExponentialOutputTest) {
     // Declare and initialize model and test parameters.
     const double alpha = 5;
     const double mu = 1.3499;
@@ -172,7 +173,7 @@ TEST(InterfaceTest, optimalEntryLevelExponentialOutputTest) {
  * no solution being found with the provided parameters.
  *
  */
-TEST(InterfaceTest, optimalExitLevelExponentialNoSolutionTest) {
+TEST(OptimalTradingLevelsTest, optimalExitLevelExponentialNoSolutionTest) {
     // Declare and initialize model and test parameters.
     const double alpha = 0.000116;
     const double mu = 1.818978;
@@ -193,7 +194,7 @@ TEST(InterfaceTest, optimalExitLevelExponentialNoSolutionTest) {
  * asserts that it is near the expected value.
  *
  */
-TEST(InterfaceTest, optimalEntryLevelLowerExponentialOutputTest) {
+TEST(OptimalTradingLevelsTest, optimalEntryLevelLowerExponentialOutputTest) {
     // Declare and initialize model and test parameters.
     const double alpha = 5;
     const double mu = 1.3499;
@@ -218,7 +219,7 @@ TEST(InterfaceTest, optimalEntryLevelLowerExponentialOutputTest) {
  * that it is near the expected value.
  *
  */
-TEST(InterfaceTest, optimalEntryLevelOutputTest) {
+TEST(OptimalTradingLevelsTest, optimalEntryLevelOutputTest) {
     // Declare and initialize model and test parameters.
     const double alpha = 8;
     const double mu = 0.3;
@@ -235,133 +236,4 @@ TEST(InterfaceTest, optimalEntryLevelOutputTest) {
     EXPECT_LE(abs(roundToDecimals(value, 8) - 0.116948), tolerance)
         << "Value produced by optimalEntryLevel function "
            "is not equal to the expected value.";
-}
-/**
- * @test Tests the output of the hittingTimeDensityOrnsteinUhlenbeck function
- * and asserts that it is near the expected value.
- *
- */
-TEST(InterfaceTest, hittingTimeDensityOutputTest) {
-    // Declare and initialize model and test parameters.
-    double alpha = 0.0045;
-    double mu = 0.998;
-    double sigma = 0.0038;
-    double first = 1.04;
-    double second = 1;
-    double x = 1.02;
-    double tolerance = 1e-5;
-
-    // Calculate the hitting time density.
-    const double value =
-        hittingTimeDensityOrnsteinUhlenbeck(x, mu, alpha, sigma, first, second);
-
-    // Assert that the value is near the expected value.
-    EXPECT_LE(abs(roundToDecimals(value, 8) - 0.43046005), tolerance)
-        << "The value of the hitting time density calculated by "
-           "hittingTimeDensityOrnsteinUhlenbeck is not equal to the expected "
-           "value.";
-}
-/**
- * @test Tests the output of the ornsteinUhlenbeckMaximumLikelihood function and
- * asserts that it is near the expected value.
- *
- */
-TEST(InterfaceTest, ornsteinUhlenbeckMaximumLikelihoodOutputTest) {
-    const float tolerance = 1e-5;
-    // Generate mock vector.
-    const std::vector<double> test_vec{0.5, 0.25, 0.5, 0.75, 1.5, 0.5};
-
-    // Generate likelihood estimates.
-    const std::unordered_map<std::string, const double> likelihood =
-        ornsteinUhlenbeckMaximumLikelihood(test_vec);
-
-    // Expect equality for mu value.
-    EXPECT_LE(abs(roundToDecimals(likelihood.at("mu"), 8) - 0.58333333),
-              tolerance)
-        << "ornsteinUhlenbeckMaximumLikelihood not calculating correct value "
-           "mu.";
-    // Expect equality for alpha value.
-    EXPECT_LE(abs(roundToDecimals(likelihood.at("alpha"), 8) - 1.06784063),
-              tolerance)
-        << "ornsteinUhlenbeckMaximumLikelihood not calculating correct value "
-           "alpha.";
-    // Expect equality for sigma value.
-    EXPECT_LE(abs(roundToDecimals(likelihood.at("sigma"), 8) - 0.15277777),
-              tolerance)
-        << "ornsteinUhlenbeckMaximumLikelihood not calculating correct value "
-           "sigma.";
-}
-/**
- * @test Tests that the getInitializedKcaState function correctly initialises
- * a KcaStates object and returns its internal state as a JSON string with the
- * correct values.
- *
- */
-TEST(InterfaceTest, getInitializedKcaStateTest) {
-    // Mock data to initialise the system.
-    const std::vector<double> data_series{
-        10.51255, 10.51985, 10.52405, 10.4656,  10.47,    10.5403,  10.4425,
-        10.3087,  10.1994,  10.1839,  10.24645, 10.1795,  10.21715, 10.14995,
-        10.194,   10.22505, 10.27325, 10.25095, 10.30575, 10.27645};
-    const double h{1.0};
-    const double q{0.001};
-    const std::string system_dimension =
-        "{\"observation_covariance_columns\":1,\"observation_covariance_rows\":"
-        "1,\"observation_matrix_columns\":3,\"observation_matrix_rows\":1,"
-        "\"observation_offset\":0.0,\"state_covariance_columns\":3,\"state_"
-        "covariance_rows\":3,\"state_mean_dimension\":3}";
-
-    // Get the initialised internal state as a JSON string from the KCA system.
-    const std::string internal_state =
-        getInitializedKcaState(data_series, h, q, system_dimension);
-    std::cout << internal_state << std::endl;
-    EXPECT_EQ(internal_state,
-              "{\"current_state_covariance\":[[0.0,0.0,0.0],[0.0,0.0,0.0],[0.0,"
-              "0.0,0.0]],\"current_state_mean\":[10.288741828687053,0.0,0.0],"
-              "\"observation_matrix\":[[1.0,0.0,0.0]],\"observation_offset\":0."
-              "0,\"transition_covariance\":[[0.12695229227341848,0.0,0.0],[0.0,"
-              "0.001,0.0],[0.0,0.0,0.001]],\"transition_matrix\":[[1."
-              "0011961162353782,1.0,0.5],[0.0,1.0,1.0],[0.0,0.0,1.0]]}")
-        << "The JSON string produced by the getInitializedKcaState "
-           "function is incorrect.";
-}
-/**
- * @test Tests that the getUpdatedKcaState function correctly performs single
- * stage update to the KCA system provided and returns a JSON object
- * representing the correct internal state.
- *
- */
-TEST(InterfaceTest, getUpdatedKcaStateTest) {
-    // Mock data to set the current state of the system.
-    const std::string state =
-        "{\"current_state_covariance\":[[0.0,0.0,0.0],[0.0,0.0,0.0],[0.0,"
-        "0.0,0.0]],\"current_state_mean\":[10.288741828687053,0.0,0.0],"
-        "\"observation_matrix\":[[1.0,0.0,0.0]],\"observation_offset\":0."
-        "0,\"transition_covariance\":[[0.12695229227341848,0.0,0.0],[0.0,"
-        "0.001,0.0],[0.0,0.0,0.001]],\"transition_matrix\":[[1."
-        "0011961162353782,1.0,0.5],[0.0,1.0,1.0],[0.0,0.0,1.0]]}";
-    const std::string system_dimension =
-        "{\"observation_covariance_columns\":1,\"observation_covariance_rows\":"
-        "1,\"observation_matrix_columns\":3,\"observation_matrix_rows\":1,"
-        "\"observation_offset\":0.0,\"state_covariance_columns\":3,\"state_"
-        "covariance_rows\":3,\"state_mean_dimension\":3}";
-    const double observation{10.3};
-    const double innovation_sigma{0.1};
-
-    // Get the updated internal kinetic components state.
-    const std::string updated_state = getUpdatedKcaState(
-        state, system_dimension, observation, innovation_sigma);
-
-    std::cout << updated_state << std::endl;
-    EXPECT_EQ(
-        updated_state,
-        "{\"current_state_covariance\":[[0.009269818720519449,0.0,0.0],[0.0,0."
-        "001,0.0],[0.0,0.0,0.001]],\"current_state_mean\":[10.3000765492722,0."
-        "0,0.0],\"observation_matrix\":[[1.0,0.0,0.0]],\"observation_offset\":"
-        "0.0,\"transition_covariance\":[[0.12695229227341848,0.0,0.0],[0.0,0."
-        "001,0.0],[0.0,0.0,0.001]],\"transition_matrix\":[[1.0011961162353782,"
-        "1.0,0.5],[0.0,1.0,1.0],[0.0,0.0,1.0]]}")
-        << "The JSON string produced "
-           "by the getUpdatedKcaState "
-           "function is incorrect.";
 }

--- a/tests/ou_model_test.cpp
+++ b/tests/ou_model_test.cpp
@@ -1,0 +1,63 @@
+#include "stochastic_models/entrypoints/ou_model.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+#include "stochastic_models/numeric_utils/helpers.h"
+
+/**
+ * @test Tests the output of the hittingTimeDensityOrnsteinUhlenbeck function
+ * and asserts that it is near the expected value.
+ *
+ */
+TEST(OuModelTest, hittingTimeDensityOutputTest) {
+    // Declare and initialize model and test parameters.
+    double alpha = 0.0045;
+    double mu = 0.998;
+    double sigma = 0.0038;
+    double first = 1.04;
+    double second = 1;
+    double x = 1.02;
+    double tolerance = 1e-5;
+
+    // Calculate the hitting time density.
+    const double value =
+        hittingTimeDensityOrnsteinUhlenbeck(x, mu, alpha, sigma, first, second);
+
+    // Assert that the value is near the expected value.
+    EXPECT_LE(abs(roundToDecimals(value, 8) - 0.43046005), tolerance)
+        << "The value of the hitting time density calculated by "
+           "hittingTimeDensityOrnsteinUhlenbeck is not equal to the expected "
+           "value.";
+}
+/**
+ * @test Tests the output of the ornsteinUhlenbeckMaximumLikelihood function and
+ * asserts that it is near the expected value.
+ *
+ */
+TEST(OuModelTest, ornsteinUhlenbeckMaximumLikelihoodOutputTest) {
+    const float tolerance = 1e-5;
+    // Generate mock vector.
+    const std::vector<double> test_vec{0.5, 0.25, 0.5, 0.75, 1.5, 0.5};
+
+    // Generate likelihood estimates.
+    const std::unordered_map<std::string, const double> likelihood =
+        ornsteinUhlenbeckMaximumLikelihood(test_vec);
+
+    // Expect equality for mu value.
+    EXPECT_LE(abs(roundToDecimals(likelihood.at("mu"), 8) - 0.58333333),
+              tolerance)
+        << "ornsteinUhlenbeckMaximumLikelihood not calculating correct value "
+           "mu.";
+    // Expect equality for alpha value.
+    EXPECT_LE(abs(roundToDecimals(likelihood.at("alpha"), 8) - 1.06784063),
+              tolerance)
+        << "ornsteinUhlenbeckMaximumLikelihood not calculating correct value "
+           "alpha.";
+    // Expect equality for sigma value.
+    EXPECT_LE(abs(roundToDecimals(likelihood.at("sigma"), 8) - 0.15277777),
+              tolerance)
+        << "ornsteinUhlenbeckMaximumLikelihood not calculating correct value "
+           "sigma.";
+}

--- a/tests/ou_model_test.cpp
+++ b/tests/ou_model_test.cpp
@@ -7,6 +7,29 @@
 #include "stochastic_models/numeric_utils/helpers.h"
 
 /**
+ * @test Tests the output of the simulateOrnsteinUhlenbeck function and asserts
+ * that it is of the correct size.
+ */
+TEST(OuModelTest, simulateOrnsteinUhlenbeckOutputTest) {
+    // Declare and initialize model and test parameters.
+    double mu = 0.5;
+    double alpha = 0.01;
+    double sigma = 0.0067;
+    double start = 0.0;
+    unsigned int size = 20;
+    unsigned int t = 1;
+
+    // Simulate the Ornstein-Uhlenbeck process.
+    const std::vector<double> series =
+        simulateOrnsteinUhlenbeck(mu, alpha, sigma, start, size, t);
+
+    // Assert that the series is of the correct size.
+    EXPECT_EQ(series.size(), size)
+        << "The size of the series returned by "
+           "simulateOrnsteinUhlenbeck is not equal to the expected size.";
+}
+
+/**
  * @test Tests the output of the hittingTimeDensityOrnsteinUhlenbeck function
  * and asserts that it is near the expected value.
  *


### PR DESCRIPTION
## **Description**
`interface.cpp` replaced by `entrypoint_*` files that are specific to the functions that they contain. This provides an opportunity to potentially create separate shared library objects in the future. A neater way of organising the code in this project.

Closes #14.

## **Message**
<!-- Detailed description - what and why this PR is created. Describe limitations/ breaking change if any -->

## **Screen Shots**
<!-- Place any screen shots / videos / links to better explain the code commit. -->

## **Is it done?**
- [x] Plan: Did you plan your implementation? If not required, explain why if not obvious.
- [x] Test: Is the change adequately tested?
- [x] Document: Is the change adequately documented?
