### PR TITLE
BUG[kca] #23: Kinematic matrices and initial state incorrectly permuted and mis-specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# Minimum version 4.0.
-cmake_minimum_required(VERSION 4.0)
+# Minimum version 4.2.
+cmake_minimum_required(VERSION 4.2)
 
 # This is a shared library project.
 option(BUILD_SHARED_LIBS "Build the shared library" ON)
@@ -7,7 +7,7 @@ option(BUILD_SHARED_LIBS "Build the shared library" ON)
 # Set the project name and version.
 project(StochasticModels
     DESCRIPTION "Core stochastic differential equation implementation of fast mathematical tools for stochastic calculus."
-    VERSION 0.2.0
+    VERSION 0.3.0
     LANGUAGES CXX)
 
 # specify the C++ standard.
@@ -17,11 +17,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 # Include the FetchContent module.
 include(FetchContent)
 
-# Fetch Boost 1.89.0
+# Fetch Boost 1.90.0
 FetchContent_Declare(
     Boost
-    URL      https://archives.boost.io/release/1.89.0/source/boost_1_89_0.tar.bz2
-    URL_HASH SHA256=85a33fa22621b4f314f8e85e1a5e2a9363d22e4f4992925d4bb3bc631b5a0c7a
+    URL      https://archives.boost.io/release/1.90.0/source/boost_1_90_0.tar.bz2
+    URL_HASH SHA256=49551aff3b22cbc5c5a9ed3dbc92f0e23ea50a0f7325b0d198b705e8ee3fc305
     EXCLUDE_FROM_ALL
     )
 FetchContent_MakeAvailable(Boost)

--- a/README.md
+++ b/README.md
@@ -120,11 +120,15 @@ $(n-1) \leftarrow n$ and $X_{\text{last}} \leftarrow X_t$
 **6. Update stateful object parameters:** $\mu$, $\alpha$, and $\sigma$ are updated in a stateful object based on the new state.
 
 ### Kinetic Components Analysis
-A kalman-filter model adapted to capture the instantaneous first and second derivatives of a stochastic process. It is based on the Kinetic Components Analysis paper by López de Prado (2016) with the ability to produce estimates given a generic stochastic process characterised by a stochastic differential equation.
+A kalman-filter model adapted to capture the instantaneous first and second derivatives of a stochastic process and subsequently extract signal from noisy measurements. It is based on the Kinetic Components Analysis paper by López de Prado (2016) with the ability to produce estimates given a generic stochastic process characterised by a stochastic differential equation.
 
-I have done my best to implement what I have read and understood from various public sources detailing the KCA method and have added the default fit of a stochastic differential equation as a slight modification. This should reduce the error of the estimates to some extent.
+I have done my best to implement what I have read and understood from various public sources detailing the KCA method and have adapted slightly based on subsequent research, initialisation of the transition covariance matrix (Q).
 
-**Citation:** López de Prado, Marcos and López de Prado, Marcos and Rebonato, Riccardo, Kinetic Component Analysis (June 5, 2016). Journal of Investing, Vol. 25, No. 3, 2016.
+**Citations:**
+
+Frederic Crouse, David, Process Noise Selection Based on Mismatched Filter Design (March 2, 2023). Naval Research Lab, Washington DC, Page 23.
+
+López de Prado, Marcos and Rebonato, Riccardo, Kinetic Component Analysis (June 5, 2016). Journal of Investing, Vol. 25, No. 3, 2016.
 
 ### Optimal Trading Levels for Mean-Reverting Assets
 The library is modularised and each component serves a specific purpose in using SDEs in mathematical analysis of trading and markets.

--- a/include/stochastic_models/kalman_filter/states.h
+++ b/include/stochastic_models/kalman_filter/states.h
@@ -286,72 +286,6 @@ struct FilterState {
 };
 
 /**
- * @brief Handles internals of the stochastic differential equation (SDE) that
- * governs the process being analysed by the kalman filtering process within the
- * KCA.
- *
- * The maximum likelihood parameters are calculated and stored within this
- * class.
- *
- * @param likelihood The likelihood calculator for the SDE process.
- * @param mu The mu parameter of the SDE process.
- * @param sigma The sigma parameter of the SDE process.
- * @param conditional_variance The conditional variance of the SDE process.
- * @param mu_numerator An internally managed value used to calculate the mu
- * parameter in initialisation and on update.
- * @param mu_denominator An internally managed value used to calculate the mu
- * parameter in initialisation and on update.
- * @param n_observations The number of observations in the data series used to
- * calculate the likelihood parameters.
- */
-class FilterGeneralSde {
-private:
-  GeneralLinearLikelihood likelihood;
-  double mu;
-  double sigma;
-  double conditional_variance;
-  double mu_numerator;
-  double mu_denominator;
-  u_int32_t n_observations;
-
-public:
-  FilterGeneralSde();
-  FilterGeneralSde(
-      const double& mu,
-      const double& sigma,
-      const double& conditional_variance,
-      const double& mu_numerator,
-      const double& mu_denominator,
-      const u_int32_t& n_observations
-  );
-  /**
-   * @brief Retrieves the current value of the mu parameter from the SDE
-   * process.
-   * @return The mu parameter of the SDE process.
-   */
-  const double& getMu() const;
-  /**
-   * @brief Retrieves the current value of the sigma parameter from the SDE
-   * process.
-   * @return The sigma parameter of the SDE process.
-   */
-  const double& getSigma() const;
-  /**
-   * @brief Retrieves the current value of the conditional covariance from the
-   * SDE process.
-   * @return The conditional covariance parameter of the SDE process.
-   */
-  const double& getConditionalVariance() const;
-  /**
-   * @brief Initializes completely the likelihood state of the SDE process
-   * from a data series.
-   * @param data_series The data series used to calculate the likelihood
-   * parameters.
-   */
-  void initializeLikelihoodState(const std::vector<double>& data_series);
-};
-
-/**
  * @brief Contains the dimensions of a Kalman Filter system.
  *
  * Internal system state dimensions are stored in this struct.
@@ -410,7 +344,6 @@ private:
   PosteriorState posterior_state;
   TransitionState transition_state;
   FilterState filter_state;
-  FilterGeneralSde filter_sde;
 
   /**
    * @brief Moves a std::vector of std::vectors to a boost uBLAS matrix.

--- a/install-cmake.sh
+++ b/install-cmake.sh
@@ -23,9 +23,9 @@ apt remove --purge --auto-remove cmake
 
 # Set cmake configuration.
 src_url="https://github.com/Kitware/CMake/releases/download"
-version="4.1"
-build="1"
-checksum="b29f6f19733aa224b7763507a108a427ed48c688e1faf22b29c44e1c30549282"
+version="4.2"
+build="3"
+checksum="7efaccde8c5a6b2968bad6ce0fe60e19b6e10701a12fce948c2bf79bac8a11e9"
 
 # Install cmake.
 mkdir ~/temp

--- a/install-valgrind.sh
+++ b/install-valgrind.sh
@@ -4,10 +4,10 @@
 set -euo pipefail
 IFS=$'\n\t'
 
-valgrind_version="3.23.0"
+valgrind_version="3.26.0"
 
 wget "https://sourceware.org/pub/valgrind/valgrind-${valgrind_version}.tar.bz2"
-valgrind_md5="c59775fcbfa82fcce796843d0aaa7538"
+valgrind_md5="856da1bc568212df6df502295a0439c0"
 
 if ! echo "$valgrind_md5 valgrind-${valgrind_version}.tar.bz2" | md5sum -c -; then
 	echo "Valgrind checksum validation failed."

--- a/src/states.cpp
+++ b/src/states.cpp
@@ -156,47 +156,6 @@ TransitionState::TransitionState(
 // Filter boolean state data class / struct implementation
 FilterState::FilterState() : initialised(false), priors_set(false) {}
 
-// General SDE state handler for managing stochastic process that governs series
-// being analysed by the KCA.
-FilterGeneralSde::FilterGeneralSde(
-    const double& mu,
-    const double& sigma,
-    const double& conditional_variance,
-    const double& mu_numerator,
-    const double& mu_denominator,
-    const u_int32_t& n_observations
-)
-    : mu(mu), sigma(sigma), conditional_variance(conditional_variance),
-      mu_numerator(mu_numerator), mu_denominator(mu_denominator),
-      n_observations(n_observations) {}
-FilterGeneralSde::FilterGeneralSde()
-    : FilterGeneralSde(0.0, 0.0, 0.0, 0.0, 0.0, 0) {}
-const double& FilterGeneralSde::getMu() const {
-  return mu;
-}
-const double& FilterGeneralSde::getSigma() const {
-  return sigma;
-}
-const double& FilterGeneralSde::getConditionalVariance() const {
-  return conditional_variance;
-}
-void FilterGeneralSde::initializeLikelihoodState(
-    const std::vector<double>& data_series
-) {
-  const GeneralLinearLikelihoodComponents components =
-      likelihood.calculateComponents(data_series);
-  const GeneralLinearParameters likelihood_values =
-      likelihood.calculateParameters(components);
-
-  mu = likelihood_values.mu;
-  sigma = likelihood_values.sigma;
-  conditional_variance =
-      likelihood.calculateConditionalVariance(likelihood_values);
-  mu_numerator = components.lead_lag_inner_product;
-  mu_denominator = components.lag_squared;
-  n_observations = components.n_obs;
-}
-
 // Type that contains internal dimensions of a Kalman Filter system.
 FilterSystemDimensions::FilterSystemDimensions()
     : state_mean_dimension(0), state_covariance_rows(0),
@@ -265,24 +224,21 @@ void KcaStates::move_std_vector_to_vector(
 void KcaStates::setInitialState(
     const std::vector<double>& data_series, const double& h, const double& q
 ) {
-  filter_sde.initializeLikelihoodState(data_series);
-
   // Initial transition state.
   std::vector<std::vector<double>> transition_matrix_as_vectors{
-      {1.0, h, 0.5 * std::pow(h, 2)},
-      {0.0, 1.0, h},
-      {0.0, 0.0, 1.0}
+      {1.0, h, 0.5 * std::pow(h, 2)}, {0.0, 1.0, h}, {0.0, 0.0, 1.0}
   };
   std::vector<std::vector<double>> transition_covariance_as_vectors{
-      {q * std::pow(h, 5) / 20.0, q * std::pow(h, 4) / 8.0, q * std::pow(h, 3) / 6.0},
-      {q * std::pow(h, 4) / 8.0, q * std::pow(h, 3) / 3.0, q * std::pow(h, 2) / 2.0},
+      {q * std::pow(h, 5) / 20.0, q * std::pow(h, 4) / 8.0,
+       q * std::pow(h, 3) / 6.0},
+      {q * std::pow(h, 4) / 8.0, q * std::pow(h, 3) / 3.0,
+       q * std::pow(h, 2) / 2.0},
       {q * std::pow(h, 3) / 6.0, q * std::pow(h, 2) / 2.0, q * h}
   };
 
   // Initial current state.
   std::vector<double> current_state_mean_as_vector{
-      data_series.at(data_series.size() - 1),
-      0.0, 0.0
+      data_series.at(data_series.size() - 1), 0.0, 0.0
   };
   std::vector<std::vector<double>> current_state_covariance_as_vectors{
       {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}

--- a/src/states.cpp
+++ b/src/states.cpp
@@ -269,19 +269,19 @@ void KcaStates::setInitialState(
 
   // Initial transition state.
   std::vector<std::vector<double>> transition_matrix_as_vectors{
-      {std::exp(filter_sde.getMu()), h, 0.5 * std::pow(h, 2)},
+      {1.0, h, 0.5 * std::pow(h, 2)},
       {0.0, 1.0, h},
       {0.0, 0.0, 1.0}
   };
   std::vector<std::vector<double>> transition_covariance_as_vectors{
-      {filter_sde.getConditionalVariance(), 0.0, 0.0},
-      {0.0, q, 0.0},
-      {0.0, 0.0, q}
+      {q * std::pow(h, 5) / 20.0, q * std::pow(h, 4) / 8.0, q * std::pow(h, 3) / 6.0},
+      {q * std::pow(h, 4) / 8.0, q * std::pow(h, 3) / 3.0, q * std::pow(h, 2) / 2.0},
+      {q * std::pow(h, 3) / 6.0, q * std::pow(h, 2) / 2.0, q * h}
   };
 
   // Initial current state.
   std::vector<double> current_state_mean_as_vector{
-      data_series.at(data_series.size() - 1) * std::exp(filter_sde.getMu()),
+      data_series.at(data_series.size() - 1),
       0.0, 0.0
   };
   std::vector<std::vector<double>> current_state_covariance_as_vectors{

--- a/tests/filter_states_test.cpp
+++ b/tests/filter_states_test.cpp
@@ -366,7 +366,7 @@ TEST(KalmanFilterStateTest, KcaStatessetInitialStateTest) {
   const std::vector<std::vector<double>> transition_matrix =
       copy_matrix_elements_to_vector(kca_states.getTransitionMatrix());
   const std::vector<std::vector<double>> expected_transition_matrix{
-      {1.0011961162353782, 1.0, 0.5}, {0.0, 1.0, 1.0}, {0.0, 0.0, 1.0}
+      {1.0, 1.0, 0.5}, {0.0, 1.0, 1.0}, {0.0, 0.0, 1.0}
   };
   EXPECT_EQ(transition_matrix, expected_transition_matrix)
       << "The transition matrix was set with invalid or inconsistent values.";
@@ -375,7 +375,9 @@ TEST(KalmanFilterStateTest, KcaStatessetInitialStateTest) {
   const std::vector<std::vector<double>> transition_covariance =
       copy_matrix_elements_to_vector(kca_states.getTransitionCovariance());
   const std::vector<std::vector<double>> expected_transition_covariance{
-      {0.12695229227341848, 0, 0}, {0, 0.001, 0}, {0, 0, 0.001}
+      {5e-05, 0.000125, 0.00016666666666666666},
+      {0.000125, 0.00033333333333333332, 0.0005},
+      {0.00016666666666666666, 0.0005, 0.001}
   };
   EXPECT_EQ(transition_covariance, expected_transition_covariance)
       << "The transition covariance was set with invalid or inconsistent "
@@ -399,7 +401,7 @@ TEST(KalmanFilterStateTest, KcaStatessetInitialStateTest) {
       current_state_mean_vector.begin()
   );
   const std::vector<double> expected_current_state_mean{
-      10.288741828687053, 0.0, 0.0
+      10.276450000000001, 0.0, 0.0
   };
   EXPECT_EQ(current_state_mean_vector, expected_current_state_mean)
       << "The current state mean vector was set with invalid or inconsistent "

--- a/tests/filter_update_test.cpp
+++ b/tests/filter_update_test.cpp
@@ -27,7 +27,7 @@ TEST(KalmanFilterUpdateTest, KineticComponentsinitialiseFilterTest) {
       << "The KineticComponents object must correctly indicate whether it is "
          "initialised.";
 
-  std::vector<double> expected_current_state_mean{10.288741828687053, 0.0, 0.0};
+  std::vector<double> expected_current_state_mean{10.276450000000001, 0.0, 0.0};
   EXPECT_EQ(kinetic_components.getCurrentState(), expected_current_state_mean)
       << "The KineticComponents object must correctly set the current state "
          "mean at initialisation.";
@@ -49,7 +49,7 @@ TEST(KalmanFilterUpdateTest, KineticComponentsupdatePriorsTest) {
   std::vector<std::vector<double>> current_state_covariance{
       {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}, {0.0, 0.0, 0.0}
   };
-  std::vector<double> current_state_mean{10.288741828687053, 0.0, 0.0};
+  std::vector<double> current_state_mean{10.276567164179106, 0.0, 0.0};
   std::vector<std::vector<double>> observation_matrix{{1.0, 0.0, 0.0}};
   const double observation_offset{0.0};
 
@@ -75,7 +75,7 @@ TEST(KalmanFilterUpdateTest, KineticComponentsupdatePriorsTest) {
       << "The KineticComponents object must correctly indicate whether its "
          "prior state is valid after prior update.";
 
-  std::vector<double> expected_current_state_mean{10.288741828687053, 0.0, 0.0};
+  std::vector<double> expected_current_state_mean{10.276567164179106, 0.0, 0.0};
   EXPECT_EQ(kinetic_components.getCurrentState(), expected_current_state_mean)
       << "The KineticComponents object must not change the value of the the "
          "current state when updating the prior state.";
@@ -164,7 +164,9 @@ TEST(KalmanFilterUpdateTest, KineticComponentsFullFilterTest) {
   // Update the posteriors with the observation.
   kinetic_components.updatePosteriors(observation, innovation_sigma);
 
-  std::vector<double> expected_current_state_mean{10.3000765492722, 0.0, 0.0};
+  std::vector<double> expected_current_state_mean{
+      10.276567164179106, 0.00029291044776119624, 0.00039054726368159494
+  };
   EXPECT_EQ(kinetic_components.getCurrentState(), expected_current_state_mean)
       << "The KineticComponents object must correctly finish a kalman filter "
          "predict and update round with the correct current state.";

--- a/tests/kca_filter_test.cpp
+++ b/tests/kca_filter_test.cpp
@@ -31,11 +31,12 @@ TEST(KcaTest, getInitializedKcaStateTest) {
   EXPECT_EQ(
       internal_state,
       "{\"current_state_covariance\":[[0.0,0.0,0.0],[0.0,0.0,0.0],[0.0,"
-      "0.0,0.0]],\"current_state_mean\":[10.288741828687053,0.0,0.0],"
+      "0.0,0.0]],\"current_state_mean\":[10.27645,0.0,0.0],"
       "\"observation_matrix\":[[1.0,0.0,0.0]],\"observation_offset\":0."
-      "0,\"transition_covariance\":[[0.12695229227341848,0.0,0.0],[0.0,"
-      "0.001,0.0],[0.0,0.0,0.001]],\"transition_matrix\":[[1."
-      "0011961162353782,1.0,0.5],[0.0,1.0,1.0],[0.0,0.0,1.0]]}"
+      "0,\"transition_covariance\":[[5e-05,0.000125,0.00016666666666666666],"
+      "[0.000125,0.0003333333333333333,0.0005],[0.00016666666666666666,0.0005,"
+      "0.001]],"
+      "\"transition_matrix\":[[1.0,1.0,0.5],[0.0,1.0,1.0],[0.0,0.0,1.0]]}"
   ) << "The JSON string produced by the getInitializedKcaState "
        "function is incorrect.";
 }


### PR DESCRIPTION
## **Description**
Closes #23.

Removes a mathematical bug that was overbearing in how the filter was initialised.

## **Message**
- Filter parameterised using the method used in the paper, with a slight change to covariance.
- Removed `FilterGeneralSde` imposing initialisation from a stochastic differential equation. This can be imposed by the user upon iterative updates.
- Allows `q` parameter to tune the degree of spectral density to control fit.
- Updated cmake, linters, system stuff.

## **Screen Shots**
<!-- Place any screen shots / videos / links to better explain the code commit. -->

## **Is it done?**
- [x] Plan: Did you plan your implementation? If not required, explain why if not obvious.
- [x] Test: Is the change adequately tested?
- [x] Document: Is the change adequately documented?
